### PR TITLE
Moved socket connection out of render() function, add callbacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 dist
 cypress/videos
 lib
+.idea


### PR DESCRIPTION
Hi,

in React.StrictMode, the way your Provider is set up unfortunately leads to duplicate connections. Also, when the component is unmounted, the old connections are never removed.

Additionally, I was missing some callbacks in the Provider to be able to fire events off of the connection and disconnection.

This PR adds these things.