### PR TITLE
Fix typings

### DIFF
--- a/packages/use-websockets/src/hooks.ts
+++ b/packages/use-websockets/src/hooks.ts
@@ -28,7 +28,7 @@ export const useLastWebsocketMessage = () => {
   return { data, error, ws };
 };
 
-export const useWebsocket = (onMessage: (data: JSON) => void) => {
+export const useWebsocket = (onMessage: (data: any) => void) => {
   const [error, setError] = useState(undefined);
   const onMessageRef = useRef(undefined);
 


### PR DESCRIPTION
The type `JSON` is referring to the namespace of `JSON` which contains `parse()` etc.
It isn't referring that it's a JSON Object.

Correct me if I'm wrong